### PR TITLE
ADN-868-changes-required-by-avalara-to-meet-their-partnership-program

### DIFF
--- a/config/initializers/avatax.rb
+++ b/config/initializers/avatax.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # DO NOT MODIFY FILE
-AVATAX_CLIENT_VERSION = "a0o33000004FH8l"
-AVATAX_HEADERS = { 'X-Avalara-UID' => AVATAX_CLIENT_VERSION }.freeze
+AVATAX_HEADERS = { 'X-Avalara-Client' => ENV.fetch('AVATAX_CLIENT_ID') }.freeze
 
 module Spree
   module Avatax


### PR DESCRIPTION
# Ticket: 
https://whitespectre.atlassian.net/browse/ADN-868

# Changes:
Header for requests to avatax api changed 

# Risk:
low lvl 

# Test:
No tests

# QA plan:
0. You should have `AVATAX_CLIENT_ID` variable in .env file with `AVATAX_CLIENT_ID=a0o5a0000064d9vAAA;Paragon;V1;heroku`
1.Go to the http://localhost:3000/admin/avatax_settings
2.Click "Test Connection" Button
3.In logs you should see new header

`X-Avalara-Client: "a0o5a0000064d9vAAA;Paragon;V1;heroku"` 

in logs:

```
I, [2021-02-11T13:54:16.010425 #4663]  INFO -- request: GET https://rest.avatax.com/api/v2/taxrates/bypostalcode?country=US&postalCode=07801
D, [2021-02-11T13:54:16.010647 #4663] DEBUG -- request: *X-Avalara-Client: "a0o5a0000064d9vAAA;Paragon;V1;heroku"*
User-Agent: "Faraday v0.17.3"
Authorization: "Basic YW50b25rb3B5bG92QG1lLmNvbTp0TEhxM1hLdWVlYlBpOGZneDNEWQ=="
I, [2021-02-11T13:54:18.045072 #4663]  INFO -- response: Status 200
D, [2021-02-11T13:54:18.045278 #4663] DEBUG -- response: date: "Thu, 11 Feb 2021 10:54:19 GMT"

```





