### PR TITLE
ADN-873-As-Paragon-I-want-to-implement-Address-Validation-to-calculate-taxes-solidus_avatax_certified-part

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,13 +7,15 @@ solidus_branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem 'solidus', github: 'solidusio/solidus', branch: solidus_branch
 gem 'solidus_auth_devise'
 
+gem 'factory_bot', '~> 4.8'
+
 case ENV['DB']
 when 'postgres'
   gem 'pg'
 when 'mysql'
   gem 'mysql2'
 else
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.4'
 end
 
 gemspec

--- a/app/assets/javascripts/spree/backend/solidus_avatax_certified.js
+++ b/app/assets/javascripts/spree/backend/solidus_avatax_certified.js
@@ -2,4 +2,4 @@
 //= require spree/address_validator
 
 Spree.routes.use_code_search = Spree.pathFor("admin/avalara_entity_use_codes")
-Spree.routes.validate_address = Spree.pathFor("admin/avatax_settings/validate_address")
+Spree.routes.validate_address = Spree.pathFor("/checkout/validate_address")

--- a/app/decorators/models/solidus_avatax_certified/spree/order_decorator.rb
+++ b/app/decorators/models/solidus_avatax_certified/spree/order_decorator.rb
@@ -44,7 +44,7 @@ module Models
         end
 
         def validate_ship_address
-          avatax_address = SolidusAvataxCertified::Address.new(self)
+          avatax_address = ::SolidusAvataxCertified::Address.new(self)
           response = avatax_address.validate
 
           return response.result if response.success?

--- a/app/models/spree/avatax_configuration.rb
+++ b/app/models/spree/avatax_configuration.rb
@@ -7,13 +7,13 @@ class Spree::AvataxConfiguration < Spree::Preferences::Configuration
   preference :environment, :string, default: -> { default_environment }
   preference :log, :boolean, default: true
   preference :log_to_stdout, :boolean, default: false
-  preference :address_validation, :boolean, default: true
+  preference :address_validation, :boolean, default: ENV['ADDRESS_VALIDATION']
   preference :address_validation_enabled_countries, :array, default: ['United States', 'Canada']
   preference :tax_calculation, :boolean, default: true
   preference :document_commit, :boolean, default: true
   preference :origin, :string, default: '{}'
-  preference :refuse_checkout_address_validation_error, :boolean, default: false
-  preference :customer_can_validate, :boolean, default: false
+  preference :refuse_checkout_address_validation_error, :boolean, default: ENV['REFUSE_CHECKOUT_ADDRESS_VALIDATION_ERROR']
+  preference :customer_can_validate, :boolean, default: ENV['CUSTOMER_CAN_VALIDATE']
   preference :raise_exceptions, :boolean, default: false
 
   def self.boolean_preferences

--- a/app/models/spree/avatax_configuration.rb
+++ b/app/models/spree/avatax_configuration.rb
@@ -7,13 +7,13 @@ class Spree::AvataxConfiguration < Spree::Preferences::Configuration
   preference :environment, :string, default: -> { default_environment }
   preference :log, :boolean, default: true
   preference :log_to_stdout, :boolean, default: false
-  preference :address_validation, :boolean, default: ENV['ADDRESS_VALIDATION']
+  preference :address_validation, :boolean, default: false
   preference :address_validation_enabled_countries, :array, default: ['United States', 'Canada']
   preference :tax_calculation, :boolean, default: true
   preference :document_commit, :boolean, default: true
   preference :origin, :string, default: '{}'
-  preference :refuse_checkout_address_validation_error, :boolean, default: ENV['REFUSE_CHECKOUT_ADDRESS_VALIDATION_ERROR']
-  preference :customer_can_validate, :boolean, default: ENV['CUSTOMER_CAN_VALIDATE']
+  preference :refuse_checkout_address_validation_error, :boolean, default: false
+  preference :customer_can_validate, :boolean, default: false
   preference :raise_exceptions, :boolean, default: false
 
   def self.boolean_preferences

--- a/spec/factories/avalara_factories.rb
+++ b/spec/factories/avalara_factories.rb
@@ -52,51 +52,6 @@ FactoryBot.define do
     initialize_with { attributes.deep_symbolize_keys }
   end
 
-  factory :avalara_transaction_calculator, class: Spree::Calculator::AvalaraTransaction do
-  end
-end
-
-FactoryBot.modify do
-  factory :tax_category, class: Spree::TaxCategory do
-    name { "TaxCategory - #{rand(999_999)}" }
-    tax_code { 'PC030000' }
-  end
-
-  factory :address, class: Spree::Address do
-    transient do
-      country_iso_code { 'US' }
-      state_code { 'AL' }
-    end
-
-    firstname { 'John' }
-    lastname { 'Doe' }
-    company { 'Company' }
-    address1 { '915 S Jackson St' }
-    address2 { '' }
-    city { 'Montgomery' }
-    state_name { 'Alabama' }
-    zipcode { '36104' }
-    phone { '555-555-0199' }
-    alternative_phone { '555-555-0199' }
-
-    state do |address|
-      if !Spree::State.find_by(name: address.state_name).nil?
-        Spree::State.find_by(name: address.state_name)
-      else
-        address.association(:state)
-      end
-    end
-
-    country do |address|
-      if address.state
-        address.state.country
-      else
-        address.association(:country, iso: country_iso_code)
-      end
-    end
-  end
-
-  factory :ship_address, parent: :address do
-    address1 { '915 S Jackson St' }
+  factory :avalara_transaction_calculator, class: 'Spree::Calculator::AvalaraTransaction' do
   end
 end

--- a/spec/modified_spree_factories/avalara_factories.rb
+++ b/spec/modified_spree_factories/avalara_factories.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+FactoryBot.modify do
+  factory :tax_category, class: Spree::TaxCategory do
+    name { "TaxCategory - #{rand(999_999)}" }
+    tax_code { 'PC030000' }
+  end
+
+  factory :address, class: Spree::Address do
+    transient do
+      country_iso_code { 'US' }
+      state_code { 'AL' }
+    end
+
+    firstname { 'John' }
+    lastname { 'Doe' }
+    company { 'Company' }
+    address1 { '915 S Jackson St' }
+    address2 { '' }
+    city { 'Montgomery' }
+    state_name { 'Alabama' }
+    zipcode { '36104' }
+    phone { '555-555-0199' }
+    alternative_phone { '555-555-0199' }
+
+    state do |address|
+      if !Spree::State.find_by(name: address.state_name).nil?
+        Spree::State.find_by(name: address.state_name)
+      else
+        address.association(:state)
+      end
+    end
+
+    country do |address|
+      if address.state
+        address.state.country
+      else
+        address.association(:country, iso: country_iso_code)
+      end
+    end
+  end
+
+  factory :ship_address, parent: :address do
+    address1 { '915 S Jackson St' }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,13 +6,17 @@ SimpleCov.start "rails"
 ENV["RAILS_ENV"] ||= "test"
 
 require File.expand_path('dummy/config/environment.rb', __dir__)
+require 'rspec/rails'
+require 'capybara'
+
+require 'spree/testing_support/preferences'
+require 'spree/testing_support/authorization_helpers'
+require 'spree/testing_support/capybara_ext'
+require 'spree/testing_support/controller_requests'
+require 'spree/testing_support/url_helpers'
+require 'spree/testing_support/order_walkthrough'
 
 require "webdrivers"
-
-require "solidus_support/extension/feature_helper"
-require 'spree/testing_support/controller_requests'
-
-Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
@@ -21,4 +25,9 @@ RSpec.configure do |config|
   config.example_status_persistence_file_path = "./spec/examples.txt"
 
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
+  config.include FactoryBot::Syntax::Methods
 end
+
+require 'database_cleaner'
+require 'spree/testing_support/factories'
+require './spec/modified_spree_factories/avalara_factories'


### PR DESCRIPTION

**Ticket:**
https://whitespectre.atlassian.net/browse/ADN-873

**Changes:**
Added new approach how we handle Address validation feature from avatax

**Related prs:**
https://bitbucket.org/whitespectre/adn-only/pull-requests/310/adn-873-as-paragon-i-want-to-implement

**Risk lvl:**
low

**Qa plan:**
1. Check that address validation works during checkout 
1.1) Go to shopping cart on checkout page
1.2) Write incorrect information into address fields 
1.4) Try to go further to payment
1.5) You should see error message on the top
![image](https://user-images.githubusercontent.com/78903153/108046322-89b7fe80-7055-11eb-9b7b-245464de70cb.png)
1.6) Write correct data into address field
1.4) Try to go further to payment page, with correct address everything should work fine 


2. Check that address validation works on addresses page in adminpanel
2.1) Go to http://admin.adn.local:3000/admin/users/16/addresses
2.2) Write incorrect information into address fields
2.3) Push `Validate Ship Address` button
2.4) You should see flash with errors
![image](https://user-images.githubusercontent.com/78903153/108047026-604ba280-7056-11eb-8294-b8b0489c6f59.png)
2.5) Do the same thing for valid address data, you should not see any errors 



